### PR TITLE
Allow lie type overrides for strokes gained

### DIFF
--- a/src/calculate-strokes-gained.js
+++ b/src/calculate-strokes-gained.js
@@ -123,6 +123,7 @@ const calculateStrokesGainedForRound = ({
   version,
   roundId,
   greenSpeedOverride,
+  lieTypeOverrides = {},
 }) => {
   const settingStrokesGainedValues =
     strokesGainedValues[roundJson.difficulty][
@@ -179,14 +180,21 @@ const calculateStrokesGainedForRound = ({
         endPosition = hole.shots[shotIndex].endPosition;
       }
 
-      const startEffectiveLie = convertLieType({
+      let startEffectiveLie = convertLieType({
         lieType: startLie,
         distanceToHole: startDistance,
       });
-      const endEffectiveLie = convertLieType({
+      let endEffectiveLie = convertLieType({
         lieType: endLie,
         distanceToHole: endDistance,
       });
+
+      if (lieTypeOverrides.hasOwnProperty(startEffectiveLie)) {
+        startEffectiveLie = lieTypeOverrides[startEffectiveLie];
+      }
+      if (lieTypeOverrides.hasOwnProperty(endEffectiveLie)) {
+        endEffectiveLie = lieTypeOverrides[endEffectiveLie];
+      }
 
       const startEffectiveDistance = calculateEffectiveDistance({
         effectiveLieType: startEffectiveLie,


### PR DESCRIPTION
We want to treat rocks as rough for strokes gained purposes for the top shots leaderboard

Shots from the rocks can have extremely high strokes gained values if they are good, since lots of the rock locations on wolf creek are pretty impossible and often result in the ball just rolling back to your feet when you try to get out of a canyon